### PR TITLE
Enabled scm versioning to fix Google colab install error

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ will yield this interactive widget:
 ## Installation
 
 ```bash
-pip install git+https://github.com/neelnanda-io/PySvelte
+pip install git+https://github.com/austinleedavis/PySvelte-fixColabSetup
 ```
 
-(Or for developing PySvelte, you can `git clone git@github.com:neelnanda-io/PySvelte.git`, `cd PySvelte`, `pip install -e . -U`. This will use your local development version when you `import pysvelte`.)
+(Or for developing PySvelte, you can `git clone git@github.com:austinleedavis/PySvelte-fixColabSetup.git`, `cd PySvelte`, `pip install -e . -U`. This will use your local development version when you `import pysvelte`.)
 
 ## Colab
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
         'typeguard~=2.0'
     ],
     include_package_data=True,
-    use_scm_version=False,
+    use_scm_version=True,
     setup_requires=['setuptools_scm'],
 )


### PR DESCRIPTION
**TLDR: This fixes an AssertionError during install within Google Colab notebooks.** 

## Error Reproduction 
This error can be reproduced by creating a new colab notebook and running `%pip install git+https://github.com/neelnanda-io/PySvelte.git -v`. The key part of the error message is:
```sh 
File "/content/PySvelte/.eggs/setuptools_scm-8.0.4-py3.10.egg/setuptools_scm/_integration/setuptools.py", line 80, in version_keyword
  assert isinstance(value, dict), "version_keyword expects a dict or True"
AssertionError: version_keyword expects a dict or True
```

## Root Cause
Previous code appeared to disable `setuptools_scm` by setting `use_scm_version` to `False`, but `setuptools_scm` was still being invoked because it's listed in `setup_requires`.